### PR TITLE
drivers: adsd3500: add support for 1024x3072 RAW8 mode

### DIFF
--- a/drivers/adsd3500/nvidia/L4T_36_4_4/src/adsd3500_mode_tbls.h
+++ b/drivers/adsd3500/nvidia/L4T_36_4_4/src/adsd3500_mode_tbls.h
@@ -84,6 +84,7 @@ enum {
 	ADSD3500_MODE_1536x768_30FPS,
 	ADSD3500_MODE_1024x896_30FPS,
 	ADSD3500_MODE_512x1792_30FPS,
+	ADSD3500_MODE_1024x3072_30FPS,
 };
 
 static const int adsd3500_30fps[] = {
@@ -168,7 +169,7 @@ static const struct camera_common_frmfmt adsd3500_frmfmt[] = {
 	{{2048, 5376}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x5376_RAW12_30FPS},   // mode67
 	{{2048, 3584}, adsd3500_30fps, 1, 0, ADSD3500_MODE_2048x3584_RAW12_30FPS},   // mode68
 
-	/* RAW8 modes (69-81) */
+	/* RAW8 modes (69-82) */
 	{{3072, 1707}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1707_30FPS},   	     // mode69
 	{{3072, 1024}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1024_30FPS},         // mode70
 	{{3072, 1366}, adsd3500_30fps, 1, 0, ADSD3500_MODE_3072x1366_30FPS},   	     // mode71
@@ -182,6 +183,7 @@ static const struct camera_common_frmfmt adsd3500_frmfmt[] = {
 	{{1536, 768},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1536x768_30FPS},          // mode79
 	{{1024, 896},  adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x896_30FPS},          // mode80
 	{{512, 1792},  adsd3500_30fps, 1, 0, ADSD3500_MODE_512x1792_30FPS},          // mode81
+	{{1024, 3072}, adsd3500_30fps, 1, 0, ADSD3500_MODE_1024x3072_30FPS},         // mode82
 
 
 	/* Add modes with no device tree support after below */

--- a/drivers/adsd3500/nvidia/L4T_36_4_4/src/nv_adsd3500.c
+++ b/drivers/adsd3500/nvidia/L4T_36_4_4/src/nv_adsd3500.c
@@ -838,6 +838,13 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
 		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
 		.link_freq_idx = 0
 	},
+	{       /* RAW8 ADSD3100 MP */
+		.width = 1024,
+		.height = 3072,
+		.pixel_rate = 488000000,
+		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+		.link_freq_idx = 0
+	},
 
 };
 

--- a/drivers/adsd3500/nvidia/L4T_36_4_4/src/tegra234-p3767-camera-p3768-adsd3500.dts
+++ b/drivers/adsd3500/nvidia/L4T_36_4_4/src/tegra234-p3767-camera-p3768-adsd3500.dts
@@ -2919,6 +2919,38 @@
 							max_exp_time = "660000";
 							embedded_metadata_height = "1";
 						};
+						mode82 {
+							mclk_khz = "104250";
+							num_lanes = "2";
+							tegra_sinterface = "serial_b";
+							phy_mode = "DPHY";
+							discontinuous_clk = "yes";
+							dpcm_enable = "false";
+							cil_settletime = "0";
+							dynamic_pixel_bit_depth = "8";
+							csi_pixel_bit_depth = "8";
+							mode_type = "bayer";
+							pixel_phase = "rggb";
+
+							active_w = "1024";
+							active_h = "3072";
+							readout_orientation = "0";
+							line_length = "1024";
+							inherent_gain = "1";
+							mclk_multiplier = "4";
+							pix_clk_hz = "625000000";
+
+							min_gain_val = "0";
+							max_gain_val = "48";
+							gain_step_pitch = "0.3";
+							min_hdr_ratio = "1";
+							max_hdr_ratio = "1";
+							min_framerate = "1.5";
+							max_framerate = "30";
+							min_exp_time = "30";
+							max_exp_time = "660000";
+							embedded_metadata_height = "1";
+						};
 						ports {
 							#address-cells = <1>;
 							#size-cells = <0>;

--- a/drivers/adsd3500/nvidia/L4T_36_4_4/src/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
+++ b/drivers/adsd3500/nvidia/L4T_36_4_4/src/tegra234-p3767-camera-p3768-dual-adsd3500-adsd3100.dts
@@ -2855,6 +2855,38 @@
 							max_exp_time = "660000";
 							embedded_metadata_height = "1";
 						};
+						mode82 {
+							mclk_khz = "104250";
+							num_lanes = "2";
+							tegra_sinterface = "serial_c";
+							phy_mode = "DPHY";
+							discontinuous_clk = "yes";
+							dpcm_enable = "false";
+							cil_settletime = "0";
+							dynamic_pixel_bit_depth = "8";
+							csi_pixel_bit_depth = "8";
+							mode_type = "bayer";
+							pixel_phase = "rggb";
+
+							active_w = "1024";
+							active_h = "3072";
+							readout_orientation = "0";
+							line_length = "1024";
+							inherent_gain = "1";
+							mclk_multiplier = "4";
+							pix_clk_hz = "625000000";
+
+							min_gain_val = "0";
+							max_gain_val = "48";
+							gain_step_pitch = "0.3";
+							min_hdr_ratio = "1";
+							max_hdr_ratio = "1";
+							min_framerate = "1.5";
+							max_framerate = "30";
+							min_exp_time = "30";
+							max_exp_time = "660000";
+							embedded_metadata_height = "1";
+						};
 						ports {
 							#address-cells = <1>;
 							#size-cells = <0>;

--- a/drivers/adsd3500/rpi/src/adsd3500.c
+++ b/drivers/adsd3500/rpi/src/adsd3500.c
@@ -887,6 +887,13 @@ static const struct adsd3500_mode_info adsd3500_mode_info_data[] = {
 		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
 		.link_freq_idx = 0
 	},
+	{       /* RAW8 ADSD3100 MP */
+		.width = 1024,
+		.height = 3072,
+		.pixel_rate = 488000000,
+		.code = MEDIA_BUS_FMT_SRGGB8_1X8,
+		.link_freq_idx = 0
+	},
 
 };
 


### PR DESCRIPTION
Add a new RAW8 mode (1024x3072 @ 30 FPS) for the ADSD3500/ADSD3100 pipeline.